### PR TITLE
Adding required remote repos to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,10 @@ Suggests:
     RUnit,
     trelliscopejs,
     xgboost
+Remotes: 
+    HBGDki/growthstandards,
+    hafen/hbgd,
+    osofr/gridisl
 License: MIT + file LICENSE
 LazyData: true
 RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ Imports:
     assertthat,
     data.table,
     dplyr,
+    ggiraph,
     ggplot2,
     gridisl,
     growthstandards,
@@ -26,7 +27,6 @@ Imports:
 Suggests:
     brokenstick (>= 0.49),
     face (>= 0.1-2),
-    ggiraph,
     h2o,
     knitr,
     magrittr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,6 @@ Imports:
     assertthat,
     data.table,
     dplyr,
-    ggiraph,
     ggplot2,
     gridisl,
     growthstandards,
@@ -27,6 +26,7 @@ Imports:
 Suggests:
     brokenstick (>= 0.49),
     face (>= 0.1-2),
+    ggiraph,
     h2o,
     knitr,
     magrittr,


### PR DESCRIPTION
I tried installing your package from Github, but it fails because there are some dependencies that live on Github only.  For this to work you just need to add a Remotes section of your DESCRIPTION file .

Here's the original error:
```
> devtools::install_github('osofr/growthcurveSL', build_vignettes = FALSE)
Downloading GitHub repo osofr/growthcurveSL@master
from URL https://api.github.com/repos/osofr/growthcurveSL/zipball/master
Installing growthcurveSL
'/Library/Frameworks/R.framework/Resources/bin/R' --no-site-file --no-environ --no-save --no-restore --quiet CMD INSTALL  \
  '/private/var/folders/gj/cm0k4b_s42j30zs376cq_5hh0000gn/T/RtmpCmWhTn/devtools27346f8e6093/osofr-growthcurveSL-5dd6c85'  \
  --library='/Library/Frameworks/R.framework/Versions/3.5/Resources/library' --install-tests 

ERROR: dependencies ‘gridisl’, ‘growthstandards’, ‘hbgd’ are not available for package ‘growthcurveSL’
* removing ‘/Library/Frameworks/R.framework/Versions/3.5/Resources/library/growthcurveSL’
Installation failed: Command failed (1)
```

After adding the remotes, I got this error below about ggiraph not being available.  I thought maybe it was because ggiraph is imported into your NAMESPACE and it's only in Suggests and not Imports, but I think it actually might be the reason below which is that the cairo dependency was not installed.  

```
** testing if installed package can be loaded
* DONE (gridisl)
'/Library/Frameworks/R.framework/Resources/bin/R' --no-site-file --no-environ --no-save --no-restore  \
  --quiet CMD INSTALL  \
  '/private/var/folders/gj/cm0k4b_s42j30zs376cq_5hh0000gn/T/RtmpCmWhTn/devtools27346113bc44/ledell-growthcurveSL-01364d3'  \
  --library='/Library/Frameworks/R.framework/Versions/3.5/Resources/library' --install-tests 

* installing *source* package ‘growthcurveSL’ ...
** R
** data
*** moving datasets to lazyload DB
** inst
** tests
** byte-compile and prepare package for lazy loading
Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
  there is no package called ‘ggiraph’
ERROR: lazy loading failed for package ‘growthcurveSL’
* removing ‘/Library/Frameworks/R.framework/Versions/3.5/Resources/library/growthcurveSL’
Installation failed: Command failed (1)
```

After installing dependencies (cairo) for ggiraph, I got through the ggiraph issue.  I did not include this edit on the PR, but it might be helpful to add a note about the cairo dependency in the README.
```
Configuration failed because cairo was not found. Try installing:
 * deb: libcairo2-dev (Debian, Ubuntu)
 * rpm: cairo-devel (Fedora, CentOS, RHEL)
 * csw: libcairo_dev (Solaris)
 * brew: cairo (OSX)
```
You can test the updates on a clean machine by doing:
```
devtools::install_github('ledell/growthcurveSL', build_vignettes = FALSE)
```


After these updates, I got the installation working on Linux, but on my (brand new) macbook running R 3.5.0, it still failed here, so there might be another dependency that's not documented somewhere.
```
** byte-compile and prepare package for lazy loading
Error in dyn.load(file, DLLpath = DLLpath, ...) : 
  unable to load shared object '/Library/Frameworks/R.framework/Versions/3.5/Resources/library/gdtools/libs/gdtools.so':
  dlopen(/Library/Frameworks/R.framework/Versions/3.5/Resources/library/gdtools/libs/gdtools.so, 6): Library not loaded: /opt/X11/lib/libcairo.2.dylib
  Referenced from: /Library/Frameworks/R.framework/Versions/3.5/Resources/library/gdtools/libs/gdtools.so
  Reason: image not found
ERROR: lazy loading failed for package ‘growthcurveSL’
* removing ‘/Library/Frameworks/R.framework/Versions/3.5/Resources/library/growthcurveSL’
Installation failed: Command failed (1)
```